### PR TITLE
Add onboarding setup modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,6 +130,28 @@
         </div>
     </div>
 
+    <!-- Onboarding Modal -->
+    <div class="modal" id="onboarding-modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3>初期設定</h3>
+            </div>
+            <div class="modal-body">
+                <div class="setting-group">
+                    <label for="onboarding-username">ユーザーネーム</label>
+                    <input type="text" id="onboarding-username" placeholder="ユーザーネームを入力">
+                </div>
+                <div class="setting-group">
+                    <label for="onboarding-api-key">Gemini API キー</label>
+                    <input type="password" id="onboarding-api-key" placeholder="Google Gemini API キーを入力">
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button class="btn primary" id="onboarding-save">開始</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Settings Modal -->
     <div class="modal" id="settings-modal">
         <div class="modal-content">

--- a/js/config.js
+++ b/js/config.js
@@ -79,6 +79,7 @@ const CAPUT_CONFIG = {
   // Storage Keys
   STORAGE_KEYS: {
     API_KEY: 'caput_gemini_api_key',
+    USER_NAME: 'caput_user_name',
     SETTINGS: 'caput_settings',
     CHAT_HISTORY: 'caput_chat_history',
     USAGE_STATS: 'caput_usage_stats',

--- a/js/main.js
+++ b/js/main.js
@@ -36,12 +36,19 @@ class CaputApp {
       // Display tools information
       this.components.ui.displayToolsInfo();
 
-      // Try to initialize agent with stored API key
-      try {
-        await this.components.agent.initialize();
-        this.showWelcomeMessage();
-      } catch (error) {
-        this.showApiKeyPrompt();
+      // Check onboarding requirements
+      const apiKey = await this.components.storage.loadApiKey();
+      const userName = this.components.storage.loadUserName();
+
+      if (!apiKey || !userName) {
+        this.components.ui.showOnboarding();
+      } else {
+        try {
+          await this.components.agent.initialize();
+          this.showWelcomeMessage();
+        } catch (error) {
+          this.showApiKeyPrompt();
+        }
       }
 
       // Set up global error handling

--- a/js/storage.js
+++ b/js/storage.js
@@ -147,6 +147,21 @@ class CaputStorage {
     localStorage.removeItem('caput_api_key_hash');
   }
 
+  // User name management
+  saveUserName(name) {
+    if (name) {
+      localStorage.setItem(CAPUT_CONFIG.STORAGE_KEYS.USER_NAME, name);
+    }
+  }
+
+  loadUserName() {
+    return localStorage.getItem(CAPUT_CONFIG.STORAGE_KEYS.USER_NAME) || null;
+  }
+
+  clearUserName() {
+    localStorage.removeItem(CAPUT_CONFIG.STORAGE_KEYS.USER_NAME);
+  }
+
   // Settings Management
   saveSettings(settings) {
     const sanitized = this.sanitizeSettings(settings);

--- a/js/ui.js
+++ b/js/ui.js
@@ -66,6 +66,12 @@ class CaputUI {
       enableSecurity: document.getElementById('enable-security'),
       saveSettings: document.getElementById('save-settings'),
       clearData: document.getElementById('clear-data'),
+
+      // Onboarding Modal
+      onboardingModal: document.getElementById('onboarding-modal'),
+      onboardingUsername: document.getElementById('onboarding-username'),
+      onboardingApiKey: document.getElementById('onboarding-api-key'),
+      onboardingSave: document.getElementById('onboarding-save'),
       
       // Loading Overlay
       loadingOverlay: document.getElementById('loading-overlay')
@@ -125,6 +131,19 @@ class CaputUI {
       this.elements.settingsModal.addEventListener('click', (e) => {
         if (e.target === this.elements.settingsModal) {
           this.hideSettings();
+        }
+      });
+    }
+
+    // Onboarding modal save
+    if (this.elements.onboardingSave) {
+      this.elements.onboardingSave.addEventListener('click', () => this.saveOnboarding());
+    }
+
+    if (this.elements.onboardingModal) {
+      this.elements.onboardingModal.addEventListener('click', (e) => {
+        if (e.target === this.elements.onboardingModal) {
+          this.hideOnboarding();
         }
       });
     }
@@ -504,6 +523,32 @@ class CaputUI {
 
   hideSettings() {
     this.elements.settingsModal.classList.remove('visible');
+  }
+
+  showOnboarding() {
+    this.elements.onboardingModal.classList.add('visible');
+  }
+
+  hideOnboarding() {
+    this.elements.onboardingModal.classList.remove('visible');
+  }
+
+  async saveOnboarding() {
+    const name = this.elements.onboardingUsername.value.trim();
+    const key = this.elements.onboardingApiKey.value.trim();
+
+    if (name) {
+      localStorage.setItem(CAPUT_CONFIG.STORAGE_KEYS.USER_NAME, name);
+    }
+    if (key) {
+      localStorage.setItem(CAPUT_CONFIG.STORAGE_KEYS.API_KEY, key);
+    }
+
+    this.hideOnboarding();
+
+    if (window.caputApp) {
+      await window.caputApp.reinitialize();
+    }
   }
 
   loadCurrentSettings() {


### PR DESCRIPTION
## Summary
- show an onboarding modal on first launch for username and Gemini API key
- persist username via new `USER_NAME` storage key
- add username helpers to storage manager
- update UI to handle onboarding modal events
- show onboarding from app init when needed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e222b4c28832483613975183a2f4e