### PR TITLE
feat: Add simulated web scraping and content extraction capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,54 @@
 #### 🔍 検索・情報収集 (SearchTools)
 - Web検索、即座検索、サイト巡回
 - トレンド分析、引用文生成
+- `scrapeWebsiteContent`: Extracts content from a given URL. Can optionally use a CSS selector to target specific elements. Currently, this tool simulates web scraping.
+    - **Parameters:**
+        - `url` (string): The URL of the website to scrape (e.g., "https://example.com").
+        - `selector` (string, optional): A CSS selector to specify which part of the page to extract (e.g., "h1", ".article-body"). If omitted, the tool attempts to extract the main content.
+    - **Returns:** An object containing:
+        - `extracted_content` (string|array): The scraped content. This might be a single string or an array of strings if multiple elements are matched by the selector.
+        - `page_title` (string): The title of the scraped page (simulated).
+        - `fetched_url` (string): The URL that was fetched.
+        - `selector_used` (string|null): The CSS selector that was used for extraction, or `null` if none was provided.
+        - `error` (string, optional): An error message if scraping failed.
+    - **Examples:**
+        - **Basic Usage (main content):**
+            ```javascript
+            // Simulates extracting main content from example.com
+            const results = await searchTools.scrapeWebsiteContent({ url: "https://example.com" });
+            console.log(results);
+            // Expected output (simulated):
+            // {
+            //   extracted_content: "Main content of Example Domain: This domain is for use in illustrative examples in documents...",
+            //   page_title: "Example Domain",
+            //   fetched_url: "https://example.com",
+            //   selector_used": null
+            // }
+            ```
+        - **Using a Selector:**
+            ```javascript
+            // Simulates extracting the H1 tag from example.com
+            const results = await searchTools.scrapeWebsiteContent({ url: "https://example.com", selector: "h1" });
+            console.log(results);
+            // Expected output (simulated):
+            // {
+            //   extracted_content: ["Example Domain"],
+            //   page_title: "Example Domain",
+            //   fetched_url: "https://example.com",
+            //   selector_used": "h1"
+            // }
+            ```
+        - **Error Handling:**
+            ```javascript
+            // Simulates an invalid URL
+            const results = await searchTools.scrapeWebsiteContent({ url: "invalid-url" });
+            console.log(results);
+            // Expected output (simulated):
+            // {
+            //   error: "Invalid URL provided. Please include http:// or https://",
+            //   fetched_url: "invalid-url"
+            // }
+            ```
 
 #### 📝 コンテンツ生成 (ContentTools)
 - ランディングページ作成、ブログ執筆

--- a/tools/content.js
+++ b/tools/content.js
@@ -6,9 +6,9 @@ class ContentTools {
 
   async buildLandingPage(params) {
     const { title, sections = [], style = 'modern', cta = 'Get Started' } = params;
-    
+
     await this.simulateDelay(3000, 6000);
-    
+
     const html = `
 <!DOCTYPE html>
 <html lang="ja">
@@ -60,9 +60,9 @@ class ContentTools {
 
   async blogWriter(params) {
     const { title, tone = 'professional', keywords = [], length = 2000 } = params;
-    
+
     await this.simulateDelay(5000, 10000);
-    
+
     const article = `# ${title}
 
 ## はじめに
@@ -115,19 +115,19 @@ ${title}は、今後ますます重要性が高まる分野です。本記事で
 
   async tweetThreader(params) {
     const { topic, tweets = 6 } = params;
-    
+
     await this.simulateDelay(2000, 4000);
-    
+
     const thread = [];
-    
+
     thread.push(`🧵 ${topic}について詳しく解説します。知っておくべき重要なポイントをまとめました。 (1/${tweets})`);
-    
+
     for (let i = 2; i <= tweets - 1; i++) {
       thread.push(`${i}. ${topic}のポイント${i-1}について。これは非常に重要な要素です。実践的な観点から見ると... (${i}/${tweets})`);
     }
-    
+
     thread.push(`まとめ: ${topic}を成功させるためには、これらの要素を総合的に考慮することが重要です。皆さんの経験もぜひ教えてください！ (${tweets}/${tweets})`);
-    
+
     return {
       thread: thread,
       topic: topic,
@@ -139,9 +139,9 @@ ${title}は、今後ますます重要性が高まる分野です。本記事で
 
   async newsletterComposer(params) {
     const { sections = 3, theme = 'technology' } = params;
-    
+
     await this.simulateDelay(3000, 5000);
-    
+
     const newsletter = `
 <!DOCTYPE html>
 <html>
@@ -162,7 +162,7 @@ ${title}は、今後ますます重要性が高まる分野です。本記事で
         <h1>週刊 ${theme} ニュースレター</h1>
         <p>${new Date().toLocaleDateString('ja-JP')}</p>
     </div>
-    
+
     ${Array.from({length: sections}, (_, i) => `
     <div class="section">
         <div class="headline">注目のニュース ${i + 1}</div>
@@ -173,7 +173,7 @@ ${title}は、今後ますます重要性が高まる分野です。本記事で
         <a href="#" class="link">続きを読む →</a>
     </div>
     `).join('')}
-    
+
     <div class="section">
         <p style="text-align: center; color: #999;">
             このニュースレターがお役に立てれば幸いです。<br>
@@ -197,11 +197,11 @@ ${title}は、今後ますます重要性が高まる分野です。本記事で
 
   async adCopyGenerator(params) {
     const { product, audience, variants = 3 } = params;
-    
+
     await this.simulateDelay(1500, 3000);
-    
+
     const copies = [];
-    
+
     const templates = [
       `🚀 ${product}で${audience}の課題を解決！今すぐ始めて、劇的な変化を体験してください。`,
       `${audience}専用の${product}が登場！限定特典付きで、今だけの特別価格でご提供。`,
@@ -209,7 +209,7 @@ ${title}は、今後ますます重要性が高まる分野です。本記事で
       `${product}があれば、${audience}の悩みは過去のもの。今すぐ無料で試してみませんか？`,
       `${audience}の成功事例続々！${product}で実現する新しい可能性を発見しよう。`
     ];
-    
+
     for (let i = 0; i < variants; i++) {
       copies.push({
         id: i + 1,
@@ -219,7 +219,7 @@ ${title}は、今後ますます重要性が高まる分野です。本記事で
         estimatedCTR: (Math.random() * 5 + 2).toFixed(2) + '%'
       });
     }
-    
+
     return {
       copies: copies,
       product: product,
@@ -231,9 +231,9 @@ ${title}は、今後ますます重要性が高まる分野です。本記事で
 
   async seoKeywordSuggester(params) {
     const { topic, count = 10 } = params;
-    
+
     await this.simulateDelay(2000, 4000);
-    
+
     const keywords = [
       { keyword: `${topic} とは`, volume: 1200, difficulty: 'Low', intent: 'Informational' },
       { keyword: `${topic} 方法`, volume: 800, difficulty: 'Medium', intent: 'How-to' },
@@ -246,13 +246,59 @@ ${title}は、今後ますます重要性が高まる分野です。本記事で
       { keyword: `${topic} メリット`, volume: 300, difficulty: 'Medium', intent: 'Informational' },
       { keyword: `${topic} デメリット`, volume: 250, difficulty: 'Low', intent: 'Informational' }
     ];
-    
+
     return {
       keywords: keywords.slice(0, count),
       topic: topic,
       totalSuggestions: count,
       averageVolume: Math.round(keywords.reduce((sum, k) => sum + k.volume, 0) / keywords.length),
       competitionLevel: 'Medium'
+    };
+  }
+
+  async extractArticleText(params) {
+    const { htmlContent } = params;
+
+    await this.simulateDelay(500, 1000);
+
+    if (!htmlContent || typeof htmlContent !== 'string') {
+      return {
+        error: "Invalid HTML content provided.",
+        extracted_text: null,
+      };
+    }
+
+    const original_length = htmlContent.length;
+
+    if (htmlContent.includes("<article>")) {
+      // Simplified simulation: extract from first <article>
+      const articleStart = htmlContent.indexOf("<article>");
+      const articleEnd = htmlContent.indexOf("</article>", articleStart);
+      let extracted_text = "Simulated extraction from <article> tag";
+      if (articleStart !== -1 && articleEnd !== -1) {
+         // Basic extraction for simulation
+        const roughExtract = htmlContent.substring(articleStart + "<article>".length, articleEnd);
+        // This is a very basic simulation, not a real HTML parser
+        extracted_text = roughExtract.replace(/<[^>]+>/g, '').trim();
+        if (!extracted_text) { // If tags were nested and resulted in empty after stripping
+            extracted_text = "Content within article tag (Simulated)";
+        } else {
+            extracted_text = `${extracted_text} (Simulated extraction from <article> tag)`;
+        }
+      }
+      return { extracted_text, original_length };
+    }
+
+    if (htmlContent.includes("<p>")) {
+      return {
+        extracted_text: "Simulated extraction of paragraph text. Found <p> tags.",
+        original_length,
+      };
+    }
+
+    return {
+      extracted_text: "Simulated generic content extraction. No specific article tags found.",
+      original_length,
     };
   }
 

--- a/tools/search.js
+++ b/tools/search.js
@@ -6,9 +6,9 @@ class SearchTools {
 
   async searchWeb(params) {
     const { query, mode = 'hybrid' } = params;
-    
+
     await this.simulateDelay(1000, 3000);
-    
+
     return {
       results: [
         {
@@ -31,9 +31,9 @@ class SearchTools {
 
   async quickLookup(params) {
     const { query } = params;
-    
+
     await this.simulateDelay(300, 800);
-    
+
     return {
       definition: `${query}とは、専門的な概念や技術を指す用語です。`,
       source: 'internal_knowledge_base',
@@ -43,9 +43,9 @@ class SearchTools {
 
   async siteCrawler(params) {
     const { domain, depth = 2 } = params;
-    
+
     await this.simulateDelay(2000, 5000);
-    
+
     return {
       urls: [
         `https://${domain}/`,
@@ -63,9 +63,9 @@ class SearchTools {
 
   async trendAnalyzer(params) {
     const { keyword, period = '30d' } = params;
-    
+
     await this.simulateDelay(1500, 3000);
-    
+
     return {
       keyword,
       period,
@@ -81,24 +81,105 @@ class SearchTools {
 
   async citationBuilder(params) {
     const { title, url, style = 'APA' } = params;
-    
+
     await this.simulateDelay(200, 500);
-    
+
     const author = "著者名";
     const year = new Date().getFullYear();
-    
+
     let citation = '';
     if (style === 'APA') {
       citation = `${author} (${year}). ${title}. Retrieved from ${url}`;
     } else if (style === 'MLA') {
       citation = `${author}. "${title}." Web. ${new Date().toLocaleDateString()}.`;
     }
-    
+
     return {
       citation,
       style,
       title,
       url
+    };
+  }
+
+  async scrapeWebsiteContent(params) {
+    const { url, selector } = params;
+
+    await this.simulateDelay();
+
+    if (!url || (!url.startsWith("http://") && !url.startsWith("https://"))) {
+      return {
+        error: "Invalid URL provided. Please include http:// or https://",
+        fetched_url: url,
+      };
+    }
+
+    if (url === "https://example.com") {
+      if (selector === "h1") {
+        return {
+          extracted_content: ["Example Domain"],
+          page_title: "Example Domain",
+          fetched_url: "https://example.com",
+          selector_used: "h1",
+        };
+      }
+      if (selector === "p") {
+        return {
+          extracted_content: [
+            "This domain is for use in illustrative examples in documents. You may use this domain in literature without prior coordination or asking for permission.",
+          ],
+          page_title: "Example Domain",
+          fetched_url: "https://example.com",
+          selector_used: "p",
+        };
+      }
+      if (!selector) { // Handles null or undefined selector
+        return {
+          extracted_content:
+            "Main content of Example Domain: This domain is for use in illustrative examples in documents...",
+          page_title: "Example Domain",
+          fetched_url: "https://example.com",
+          selector_used: null,
+        };
+      }
+      // If selector is present but not "h1" or "p" for example.com, it will fall through to default.
+      // This is acceptable as per current logic, but could be made more specific if needed.
+    }
+
+    if (url === "https://www.wikipedia.org") {
+      if (selector === ".central-textlogo-wrapper span") {
+        return {
+          extracted_content: ["Wikipedia"],
+          page_title: "Wikipedia, the free encyclopedia",
+          fetched_url: "https://www.wikipedia.org",
+          selector_used: ".central-textlogo-wrapper span",
+        };
+      }
+      if (!selector) { // Handles null or undefined selector
+        return {
+          extracted_content:
+            "Main content of Wikipedia: Wikipedia is a multilingual free online encyclopedia...",
+          page_title: "Wikipedia, the free encyclopedia",
+          fetched_url: "https://www.wikipedia.org",
+          selector_used: null,
+        };
+      }
+      // If selector is present but not the specific one for wikipedia, it falls through.
+    }
+
+    // Default case for other URLs
+    let contentMessage;
+    if (!selector) {
+      contentMessage = `Main content from ${url} would be extracted here using a content processing function (like extractArticleText) (simulated).`;
+    } else {
+      contentMessage = `Successfully scraped content from ${url} using selector '${selector}' (simulated).`;
+    }
+
+    return {
+      extracted_content: contentMessage,
+      page_title: `Simulated Page for ${url}`,
+      fetched_url: url,
+      selector_used: selector || null,
     };
   }
 


### PR DESCRIPTION
This commit introduces new capabilities for simulated web scraping and content extraction.

New Features:
- I can now simulate fetching content from a URL.
    - This includes support for an optional CSS selector for targeted extraction.
    - I'll return mock data for predefined sites (example.com, wikipedia.org) and generic responses for others.
    - Basic URL validation is also included.
- I can now simulate extracting main article text from a given HTML string.
    - I'll identify content within `<article>` tags or based on `<p>` tags as a fallback.

Documentation:
- I've updated `README.md` to include detailed documentation for my web content fetching capability, including parameters, return values, and usage examples.

My ability to fetch web content now also conceptually integrates the idea of using a function to extract main content when no specific selector is provided. These capabilities provide a foundational interface for future web scraping implementations.